### PR TITLE
fix mismatches with greenlight

### DIFF
--- a/itest/tests/test_description_hash.py
+++ b/itest/tests/test_description_hash.py
@@ -7,6 +7,6 @@ def test_description_hash(node_factory):
     invoice = recipient.rpc.invoice(
         1_000_000, "trampoline", "trampoline", deschashonly=True
     )
-    helpers.send_onion(sender, trampoline, invoice, 1_005_000, 1_005_000)
+    helpers.send_onion(sender, trampoline, invoice, 1_005_000, 1_005_000, 1_000_000)
     result = sender.rpc.waitsendpay(invoice["payment_hash"])
     assert result["status"] == "complete"

--- a/itest/tests/test_force_close.py
+++ b/itest/tests/test_force_close.py
@@ -8,7 +8,9 @@ def test_force_close(node_factory):
         node_factory, hodl_plugin=True, may_reconnect=False
     )
     invoice = recipient.rpc.invoice(500_000_000, "trampoline", "trampoline")
-    helpers.send_onion(sender, trampoline, invoice, 502_500_000, 502_500_000)
+    helpers.send_onion(
+        sender, trampoline, invoice, 502_500_000, 502_500_000, 500_000_000
+    )
     wait_for(lambda: len(recipient.rpc.listpeerchannels()["channels"][0]["htlcs"]) > 0)
 
     # force close from sender

--- a/itest/tests/test_inflight_restart.py
+++ b/itest/tests/test_inflight_restart.py
@@ -9,7 +9,7 @@ def test_inflight_restart(node_factory):
     )
     invoice = recipient.rpc.invoice(1_000_000, "trampoline", "trampoline")
 
-    helpers.send_onion(sender, trampoline, invoice, 1_005_000, 1_005_000)
+    helpers.send_onion(sender, trampoline, invoice, 1_005_000, 1_005_000, 1_000_000)
     wait_for(lambda: len(recipient.rpc.listpeerchannels()["channels"][0]["htlcs"]) > 0)
     trampoline.restart()
     trampoline.connect(recipient)

--- a/itest/tests/test_partial_resolve.py
+++ b/itest/tests/test_partial_resolve.py
@@ -30,7 +30,9 @@ def test_partial_resolve(node_factory):
     invoice = recipient.rpc.invoice(
         1_000_000_000, "trampoline", "trampoline", preimage=preimage
     )
-    helpers.send_onion(sender, trampoline, invoice, 1_005_000_000, 1_005_000_000)
+    helpers.send_onion(
+        sender, trampoline, invoice, 1_005_000_000, 1_005_000_000, 1_000_000_000
+    )
 
     # Wait for all parts to arrive at the recipient
     wait_for(

--- a/itest/tests/test_pay_trampoline_node.py
+++ b/itest/tests/test_pay_trampoline_node.py
@@ -5,6 +5,6 @@ import helpers
 def test_pay_trampoline_node(node_factory):
     sender, trampoline, recipient = helpers.setup(node_factory)
     invoice = trampoline.rpc.invoice(1_000_000, "trampoline", "trampoline")
-    helpers.send_onion(sender, trampoline, invoice, 1_005_000, 1_005_000)
+    helpers.send_onion(sender, trampoline, invoice, 1_005_000, 1_005_000, 1_000_000)
     result = sender.rpc.waitsendpay(invoice["payment_hash"])
     assert result["status"] == "complete"

--- a/itest/tests/test_trampoline.py
+++ b/itest/tests/test_trampoline.py
@@ -5,6 +5,6 @@ import helpers
 def test_trampoline_payment(node_factory):
     sender, trampoline, recipient = helpers.setup(node_factory)
     invoice = recipient.rpc.invoice(1_000_000, "trampoline", "trampoline")
-    helpers.send_onion(sender, trampoline, invoice, 1_005_000, 1_005_000)
+    helpers.send_onion(sender, trampoline, invoice, 1_005_000, 1_005_000, 1_000_000)
     result = sender.rpc.waitsendpay(invoice["payment_hash"])
     assert result["status"] == "complete"

--- a/src/tlv.rs
+++ b/src/tlv.rs
@@ -1,4 +1,5 @@
-use bytes::Buf;
+use anyhow::anyhow;
+use bytes::{Buf, BufMut};
 use serde::{Deserialize, Deserializer};
 
 #[derive(Clone, Debug, PartialEq)]
@@ -18,6 +19,29 @@ pub struct SerializedTlvStream {
 impl SerializedTlvStream {
     pub fn get(&self, typ: u64) -> Option<TlvEntry> {
         self.entries.iter().find(|e| e.typ == typ).cloned()
+    }
+
+    pub fn remove(&mut self, typ: u64) {
+        if let Some(position) = self.entries.iter().position(|e| e.typ == typ) {
+            self.entries.remove(position);
+        }
+    }
+
+    pub fn insert(&mut self, e: TlvEntry) -> Result<(), anyhow::Error> {
+        if let Some(old) = self.get(e.typ) {
+            return Err(anyhow::anyhow!(
+                "TlvStream contains entry of type={}, old={:?}, new={:?}",
+                e.typ,
+                old,
+                e
+            ));
+        }
+
+        self.entries.push(e);
+        self.entries
+            .sort_by(|a, b| a.typ.partial_cmp(&b.typ).unwrap());
+
+        Ok(())
     }
 }
 
@@ -40,6 +64,13 @@ impl FromBytes for SerializedTlvStream {
         while b.remaining() >= 2 {
             let typ = b.get_compact_size();
             let len = b.get_compact_size() as usize;
+            if b.remaining() < len {
+                return Err(anyhow!(
+                    "trying to advance {}, but remaining length is {}",
+                    len,
+                    b.remaining()
+                ));
+            }
             let value = b.copy_to_bytes(len).to_vec();
             entries.push(TlvEntry { typ, value });
         }
@@ -49,6 +80,10 @@ impl FromBytes for SerializedTlvStream {
 }
 
 pub type CompactSize = u64;
+
+/// A variant of CompactSize that works on length-delimited
+/// buffers and therefore does not require a length prefix
+pub type TU64 = u64;
 
 /// Extensions on top of `Buf` to include LN proto primitives
 pub trait ProtoBuf: Buf {
@@ -60,11 +95,60 @@ pub trait ProtoBuf: Buf {
             v => v.into(),
         }
     }
+
+    fn get_tu64(&mut self) -> Result<TU64, anyhow::Error> {
+        Ok(match self.remaining() {
+            1 => self.get_u8() as u64,
+            2 => self.get_u16() as u64,
+            4 => self.get_u32() as u64,
+            8 => self.get_u64(),
+            l => return Err(anyhow::anyhow!("Unexpect TU64 length: {}", l)),
+        })
+    }
 }
 
 impl ProtoBuf for bytes::Bytes {}
 impl ProtoBuf for &[u8] {}
 impl ProtoBuf for bytes::buf::Take<bytes::Bytes> {}
+
+pub trait ProtoBufMut: bytes::BufMut {
+    fn put_compact_size(&mut self, cs: CompactSize) {
+        match cs {
+            0..=0xFC => self.put_u8(cs as u8),
+            0xFD..=0xFFFF => {
+                self.put_u8(253);
+                self.put_u16(cs as u16);
+            }
+            0x10000..=0xFFFFFFFF => {
+                self.put_u8(254);
+                self.put_u32(cs as u32);
+            }
+            v => {
+                self.put_u8(255);
+                self.put_u64(v);
+            }
+        }
+    }
+}
+
+impl ProtoBufMut for bytes::BytesMut {}
+
+pub trait ToBytes: Sized {
+    fn to_bytes(s: Self) -> Vec<u8>;
+}
+
+impl ToBytes for SerializedTlvStream {
+    fn to_bytes(s: Self) -> Vec<u8> {
+        let mut b = bytes::BytesMut::new();
+
+        for e in s.entries.iter() {
+            b.put_compact_size(e.typ);
+            b.put_compact_size(e.value.len() as u64);
+            b.put(&e.value[..]);
+        }
+        b.to_vec()
+    }
+}
 
 impl<'de> Deserialize<'de> for SerializedTlvStream {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -73,9 +157,23 @@ impl<'de> Deserialize<'de> for SerializedTlvStream {
     {
         // Start by reading the hex-encoded string
         let s: String = Deserialize::deserialize(deserializer)?;
-        let mut b: bytes::Bytes = hex::decode(s)
-            .map_err(|e| serde::de::Error::custom(e.to_string()))?
-            .into();
+        let b = hex::decode(s).map_err(|e| serde::de::Error::custom(e.to_string()))?;
+
+        SerializedTlvStream::try_from(b).map_err(|e| serde::de::Error::custom(e.to_string()))
+    }
+}
+
+impl From<Vec<TlvEntry>> for SerializedTlvStream {
+    fn from(value: Vec<TlvEntry>) -> Self {
+        SerializedTlvStream { entries: value }
+    }
+}
+
+impl TryFrom<Vec<u8>> for SerializedTlvStream {
+    type Error = anyhow::Error;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        let mut b: bytes::Bytes = value.into();
 
         if b.is_empty() {
             return Ok(SerializedTlvStream {
@@ -86,12 +184,6 @@ impl<'de> Deserialize<'de> for SerializedTlvStream {
         let l = b.get_compact_size();
         let b = b.take(l as usize); // Protect against overruns
 
-        Self::from_bytes(b.into_inner()).map_err(|e| serde::de::Error::custom(e.to_string()))
-    }
-}
-
-impl From<Vec<TlvEntry>> for SerializedTlvStream {
-    fn from(value: Vec<TlvEntry>) -> Self {
-        SerializedTlvStream { entries: value }
+        Self::from_bytes(b.into_inner())
     }
 }


### PR DESCRIPTION
- the invoice and amount TLVs are in payment_metadata
- The payment metadata tlv fields are stripped when continuing a htlc without handling it
- the amount TLV is a TU64, not a u64
- The pay-to-self with continue trick doesn't work, so actually send a payment to self