### PR TITLE
handle tu64 fields of any size

### DIFF
--- a/src/cln_plugin/mod.rs
+++ b/src/cln_plugin/mod.rs
@@ -814,12 +814,9 @@ where
 
                         // Send to notification to the wildcard
                         // subscription "*" it it exists
-                        match &self.wildcard_subscription {
-                            Some(cb) => {
-                                let call = cb(plugin.clone(), params.clone());
-                                tokio::spawn(async move { call.await.unwrap() });
-                            }
-                            None => {}
+                        if let Some(cb) = &self.wildcard_subscription {
+                            let call = cb(plugin.clone(), params.clone());
+                            tokio::spawn(async move { call.await.unwrap() });
                         };
 
                         // Find the appropriate callback and process it


### PR DESCRIPTION
tu64 is a truncated integer, with omitted leading zero bytes. This means a tu64 can be any length. Previously the `get_tu64` function could only handle tu64 fields with a length of 1, 2, 4 or 8. Now it can handle all lengths.

Greenlight truncates the leading zero bytes here:
https://github.com/Blockstream/greenlight/blob/3a913fef893cc04d374c29853a45bb225349ea1b/libs/gl-plugin/src/tlv.rs#L146-L151

Fixes the error: `Got invalid amount of len 3 in htlc TLV: Unexpect TU64 length: 3`