### PR TITLE
make payment timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,22 +25,24 @@ to core lightning on startup.
 ```
 --trampoline-policy-cltv-delta <arg>              Cltv expiry delta for the trampoline routing policy. Any routes where
                                                   the total cltv delta is lower than this number will not be tried.
-                                                   (default: 1008)
---trampoline-no-self-route-hints                  If this flag is set, invoices where the current node is in an invoice
-                                                  route hint are not supported. This can be useful if there are other
-                                                  important plugins acting only on forwards. The trampoline plugin will
-                                                  'receive' and 'pay', so has different dynamics.
---trampoline-policy-fee-per-satoshi <arg>         This is the proportional fee to charge for every trampoline payment
-                                                  which passes through. As percentages are too coarse, it's in
-                                                  millionths, so 10000 is 1%, 1000 is 0.1%. (default: 5000)
---trampoline-policy-fee-base <arg>                The base fee to charge for every trampoline payment which passes
-                                                  through. (default: 0)
---trampoline-mpp-timeout <arg>                    Timeout in seconds before multipart htlcs that don't add up to the
-                                                  payment amount are failed back to the sender. (default: 60)
+                                                  (default: 1008)
 --trampoline-cltv-delta <arg>                     The number of blocks between incoming payments and outgoing payments:
                                                   this needs to be enough to make sure that if we have to, we can close
                                                   the outgoing payment before the incoming, or redeem the incoming once
                                                   the outgoing is redeemed. (default: 34)
+--trampoline-policy-fee-base <arg>                The base fee to charge for every trampoline payment which passes
+                                                  through. (default: 0)
+--trampoline-policy-fee-per-satoshi <arg>         This is the proportional fee to charge for every trampoline payment
+                                                  which passes through. As percentages are too coarse, it's in
+                                                  millionths, so 10000 is 1%, 1000 is 0.1%. (default: 5000)
+--trampoline-no-self-route-hints                  If this flag is set, invoices where the current node is in an invoice
+                                                  route hint are not supported. This can be useful if there are other
+                                                  important plugins acting only on forwards. The trampoline plugin will
+                                                  'receive' and 'pay', so has different dynamics.
+--trampoline-mpp-timeout <arg>                    Timeout in seconds before multipart htlcs that don't add up to the
+                                                  payment amount are failed back to the sender. (default: 60)
+--trampoline-payment-timeout <arg>                Maximum time in seconds to attempt to find a route to the destination.
+                                                  (default: 60)
 ```
 
 ## Testing


### PR DESCRIPTION
Make the payment timeout configurable with the option `trampoline-payment-timeout`. Previously this was hardcoded to 30 seconds. Now the value in configurable, with a default of 60 seconds. 